### PR TITLE
WIP lots of changes by Sweth playing around

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,7 @@ jspm_packages
 
 # Output of 'npm pack'
 *.tgz
+
+# data
+data
+time.txt

--- a/package.json
+++ b/package.json
@@ -11,6 +11,6 @@
   "license": "MIT",
   "dependencies": {
     "jira-connector": "^2.3.0",
-    "moment": "^2.15.1",
+    "moment": "^2.15.1"
   }
 }


### PR DESCRIPTION
- Added ability to specify an input file on CLI
- Created a git-ignored data dir where config and input files can be stored without cluttering up the git repo with things like personal credentials, while falling back to the default config.js and time.txt if needed
- Added in a little more verbosity, including confirming the components in `log` that were passed in.
